### PR TITLE
Rjm/remoteuser

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,12 @@ A Cornell University CIT Custom Development starter kit package for Laravel.
    ```
    This will publish a `README.md` and `.lando.yml` file to the base directory, configured on the project settings. It will also publish HTML/CSS/JS assets from [cwd_framework_lite](https://github.com/CU-CommunityApps/cwd_framework_lite) and a set of [view components](https://laravel.com/docs/9.x/blade#layouts-using-components) that can be used to begin a layout (see `views/cwd-framework-index.blade.php` for example usage).
 
+Optional:
+   To publish the configuration file for the Starter Kit
+   ```shell
+   php artisan vendor:publish --tag="starterkit-config"
+   ```
+
 ## Contributing
 
 Anyone on the Custom Development team should be welcome and able to contribute. See [CONTRIBUTING](CONTRIBUTING.md) for details on how be involved and provide quality contributions.

--- a/config/starterkit.php
+++ b/config/starterkit.php
@@ -3,17 +3,21 @@
 return [
 
     /* 
-     * The users' netid will be retrieved from an environment variable
+     * The users' netid may be retrieved from an environment variable
      * populated by the Apache shibboleth module.  
-     * The default env variable is REMOTE USER, but this may be e.g, 
-     * REDIRECT_REMOTE_USER on some servers.
      * 
+     * The default env variable is REMOTE USER, but this may be e.g, 
+     * REDIRECT_REMOTE_USER on some servers, depending on how PHP is installed.
+     * 
+     * This configuration allows configuration of the remote_user_variable so it
+     * is not hardcoded in the application. 
+     * 
+     * In project code, use env(config('starterkit.remote_user_variable')) to retrieve the netid
+     *
      * For local development without shibboleth, you can add
      * REMOTE_USER=<netid>
      * to your project .env file to set the user netid. 
-     * 
-     * In project code, use env(config('starterkit.remote_user_variable')) to retrieve the netid
-     * 
+     *
      */
     'remote_user_variable' => env("REMOTE_USER_VARIABLE", "REMOTE_USER"),
 

--- a/config/starterkit.php
+++ b/config/starterkit.php
@@ -1,0 +1,20 @@
+<?php
+
+return [
+
+    /* 
+     * The users' netid will be retrieved from an environment variable
+     * populated by the Apache shibboleth module.  
+     * The default env variable is REMOTE USER, but this may be e.g,  , 
+     * REDIRECT_REMOTE_USER on some servers.
+     * 
+     * For local development without shibboleth, you can add
+     * REMOTE_USER=<netid>
+     * to your project .env file to set the user netid. 
+     * 
+     * In project code, use config('starterkit.netid') to retrieve the netid
+     * 
+     */
+    'netid' => env("REMOTE_USER_VARIABLE", "REMOTE_USER"),
+
+];

--- a/config/starterkit.php
+++ b/config/starterkit.php
@@ -5,16 +5,16 @@ return [
     /* 
      * The users' netid will be retrieved from an environment variable
      * populated by the Apache shibboleth module.  
-     * The default env variable is REMOTE USER, but this may be e.g,  , 
+     * The default env variable is REMOTE USER, but this may be e.g, 
      * REDIRECT_REMOTE_USER on some servers.
      * 
      * For local development without shibboleth, you can add
      * REMOTE_USER=<netid>
      * to your project .env file to set the user netid. 
      * 
-     * In project code, use config('starterkit.netid') to retrieve the netid
+     * In project code, use env(config('starterkit.remote_user_variable')) to retrieve the netid
      * 
      */
-    'netid' => env("REMOTE_USER_VARIABLE", "REMOTE_USER"),
+    'remote_user_variable' => env("REMOTE_USER_VARIABLE", "REMOTE_USER"),
 
 ];

--- a/src/StarterKitServiceProvider.php
+++ b/src/StarterKitServiceProvider.php
@@ -58,6 +58,7 @@ class StarterKitServiceProvider extends PackageServiceProvider
     {
         $package
             ->name(self::PACKAGE_NAME)
+            ->hasConfigFile()
             ->hasInstallCommand(function (InstallCommand $command) {
                 $command->startWith(fn (InstallCommand $c) => $this->install($c));
             });


### PR DESCRIPTION
Description / context for this PR:

The remote user variable set by the Apache shibboleth module differs from instance to instance depending on 
how PHP was installed.  On some instances the variable is REMOTE_USER, on others it is REDIRECT_REMOTE_USER
or other variants.  Instead of hardcoding this value, a configuration parameter remote_user_variable is used
to contain the variable name.  This is defaulted to REMOTE_USER.

In project code, use env(config('starterkit.remote_user_variable')) to retrieve the netid. 

**To Review:**

Set variables in the .env file
REMOTE_USER_VARIABLE=YOURVARIABLE
YOURVARIABLE=ewe2

- [ ] (optionally) Publish the configuration file using the instructions added to the README file
- [ ] Verify (e.g., using artisan tinker) that you can retrieve the user netid using the expression above. 
