### PR TITLE
Laravel linting update fix

### DIFF
--- a/.github/workflows/laravel-pint.yml
+++ b/.github/workflows/laravel-pint.yml
@@ -5,10 +5,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Run Laravel Pint
-        uses: aglipanci/laravel-pint-action@1.0.0
+        uses: aglipanci/laravel-pint-action@latest
         with:
           verboseMode: true
           testMode: true
+

--- a/composer.json
+++ b/composer.json
@@ -6,15 +6,15 @@
   "require": {
     "php": "^8.2",
     "livewire/livewire": "^3.5",
-    "spatie/laravel-package-tools": "^1.16",
+    "spatie/laravel-package-tools": "^1.18",
     "cubear/cwd_framework_lite": "^3.0",
     "propaganistas/laravel-phone": "^5.3",
-    "giggsey/locale": "^2.6"
+    "giggsey/locale": "^2.7"
   },
   "require-dev": {
-    "orchestra/testbench": "^8.24",
+    "orchestra/testbench": "^8.31",
     "phpunit/phpunit": "^10.5",
-    "laravel/pint": "^1.17"
+    "laravel/pint": "^1.20"
   },
   "autoload": {
     "psr-4": {

--- a/pint.json
+++ b/pint.json
@@ -1,3 +1,6 @@
 {
-  "preset": "laravel"
+  "preset": "laravel",
+  "rules": {
+    "php_unit_method_casing": false
+  }
 }

--- a/tests/Feature/InstallStarterKitTest.php
+++ b/tests/Feature/InstallStarterKitTest.php
@@ -10,7 +10,7 @@ use Illuminate\Testing\PendingCommand;
 
 class InstallStarterKitTest extends TestCase
 {
-    public function setUp(): void
+    protected function setUp(): void
     {
         parent::setUp();
         $this->resetInstallFiles();

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -7,7 +7,7 @@ use Orchestra\Testbench\TestCase as OrchestraTestCase;
 
 class TestCase extends OrchestraTestCase
 {
-    public function setUp(): void
+    protected function setUp(): void
     {
         parent::setUp();
         // additional setup


### PR DESCRIPTION
Laravel [pint got an update](https://github.com/laravel/pint/pull/300) that newly enforced snake_case for phpunit test names. Current code fails that test, so this code adjusts for it.

**This PR does the following**

- Updates to latest Laravel pint and other composer updates
- Adds a pint.json rule configuration to not run the new phpunit casing test
- Applies latest linting with pint
- Updates github workflows to keep current

**To Review:**

- [x] Confirm workflow checks pass
- [ ] Review code